### PR TITLE
cliでの型チェック処理を削除し、型チェック結果を受け取って処理するだけにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ts-expect-errors
 
-TypeScript プロジェクトのタイプチェックを実行し、検出されたエラー箇所に自動的に `@ts-expect-error` コメントを挿入してエラーを抑制する CLI ツール。
+TypeScript/Vue.js プロジェクトの型チェック結果を受け取り、検出されたエラー箇所に自動的に `@ts-expect-error` コメントを挿入してエラーを抑制する CLI ツール。
 
 ## 概要
 
-- TypeScript コンパイラを使用してプロジェクト全体のタイプエラーを検出
+- TypeScript コンパイラ（tsc/vue-tsc）の出力を解析
 - 各エラー箇所の直前に `@ts-expect-error` コメントを自動挿入
 - 既存コードのエラーを一時的に抑制し、段階的な型安全性の改善を支援
+- 標準入力またはファイルから型チェック結果を受け取り可能
 
 ## 実装
 
@@ -30,11 +31,15 @@ bun install
 ### エラー抑制コメントの追加
 
 ```sh
-# プロジェクトのタイプエラーを検出し、@ts-expect-errorコメントを挿入
-bun run src/index.ts --project <project-directory>
+# 標準入力から型チェック結果を受け取って処理
+tsc --noEmit | bun run src/index.ts
+vue-tsc --noEmit | bun run src/index.ts
 
-# Vue.jsプロジェクトの場合
-bun run src/index.ts --project <project-directory> --checker vue-tsc
+# ファイルから型チェック結果を読み込んで処理
+bun run src/index.ts --log-file tsc-output.txt
+
+# 特定のディレクトリを基準にファイルパスを解決
+tsc --noEmit | bun run src/index.ts --target ./src
 ```
 
 ### エラー抑制コメントの削除
@@ -48,8 +53,8 @@ bun run src/index.ts remove --target <target-directory>
 
 #### メインコマンド（エラー抑制コメントの追加）
 
-- `--project` / `-p`: プロジェクトディレクトリパス（デフォルト: `.`）
-- `--checker` / `-c`: タイプチェッカーの選択（`tsc` または `vue-tsc`、デフォルト: `tsc`）
+- `--target` / `-t`: ファイルパス解決の基準ディレクトリ（デフォルト: `.`）
+- `--log-file` / `-l`: 型チェック結果のログファイルパス（未指定時は標準入力から読み込み）
 
 #### remove サブコマンド（エラー抑制コメントの削除）
 
@@ -57,6 +62,7 @@ bun run src/index.ts remove --target <target-directory>
 
 ### 重要な仕様
 
+- 型チェックは外部で実行し、その結果をパイプまたはファイル経由で渡す
 - Vue テンプレートでは `@vue-expect-error` を使用
 - TSX では要素内で `{/* @ts-expect-error */}` 形式のコメントを使用
 - remove コマンドは`.gitignore`の内容を自動的に考慮して除外

--- a/src/commands/add/core.ts
+++ b/src/commands/add/core.ts
@@ -1,6 +1,4 @@
-import { $ } from "bun";
 import { resolve } from "node:path";
-import { readFile, exists } from "node:fs/promises";
 import { processTsExpectErrors } from "./processors/ts-processor";
 import { processTsxExpectErrors } from "./processors/tsx-processor";
 import { processVueExpectErrors } from "./processors/vue-processor";
@@ -45,64 +43,17 @@ function parseTscOutput(output: string): TsError[] {
   return errors;
 }
 
-// ログファイルからtsc出力を読み込む
-async function readTscOutputFromFile(logFilePath: string): Promise<string | null> {
-  const resolvedPath = resolve(logFilePath);
-  
-  // ログファイルの存在確認
-  if (!await exists(resolvedPath)) {
-    console.error(`Log file not found: ${resolvedPath}`);
-    process.exit(1);
-  }
-  
-  console.log(`Reading log file: ${resolvedPath}...`);
-  const content = await readFile(resolvedPath, 'utf-8');
-  
-  // ログファイルが空の場合
-  if (!content.trim()) {
-    console.log('Log file is empty. No TypeScript errors to process.');
-    return null;
-  }
-  
-  return content;
-}
-
-// tscまたはvue-tscを実行してエラーを取得
-async function runTypeScriptChecker(projectPath: string, checker: string): Promise<string | null> {
-  console.log(`Running ${checker} in ${projectPath}...`);
-  
-  try {
-    console.log(`Executing: npx ${checker} --noEmit in ${projectPath}`);
-    const result = await $`npx ${checker} --noEmit`.cwd(projectPath).nothrow();
-    
-    if (result.exitCode === 0) {
-      console.log('No TypeScript errors found.');
-      return null;
-    }
-    
-    if (result.exitCode === 127) {
-      console.error(`Command not found: ${checker}`);
-      console.error('stderr:', result.stderr.toString());
-      throw new Error(`${checker} command not found in ${projectPath}`);
-    }
-    
-    return result.stdout.toString();
-  } catch (error) {
-    console.error(`Error running ${checker}:`, error);
-    throw error;
-  }
-}
 
 
 // エラーを処理してファイルにコメントを挿入
-async function processErrors(errors: TsError[], projectPath: string): Promise<void> {
+async function processErrors(errors: TsError[], targetPath: string): Promise<void> {
   
   console.log(`Found ${errors.length} errors`);
   
   // ファイルごとにエラーをグループ化
   const errorsByFile = new Map<string, TsError[]>();
   for (const error of errors) {
-    const filePath = resolve(projectPath, error.file);
+    const filePath = resolve(targetPath, error.file);
     const existing = errorsByFile.get(filePath) || [];
     existing.push(error);
     errorsByFile.set(filePath, existing);
@@ -133,31 +84,14 @@ async function processErrors(errors: TsError[], projectPath: string): Promise<vo
 }
 
 // メインの処理関数
-export async function processTypeScriptErrors(options: {
-  project: string;
-  checker: string;
-  "log-file"?: string;
-}): Promise<void> {
-  const { project, checker } = options;
-  const projectPath = resolve(project);
-  const logFile = options["log-file"];
+export async function processTypeScriptErrors(tscOutput: string, targetPath: string): Promise<void> {
+  // エラー出力をパース
+  const errors = parseTscOutput(tscOutput);
   
-  // ログファイルが指定されている場合は読み込み
-  if (logFile) {
-    const tscOutput = await readTscOutputFromFile(logFile);
-    if (!tscOutput) return; // 空またはエラーの場合は終了
-    
-    // エラー出力をパース
-    const errors = parseTscOutput(tscOutput);
-    await processErrors(errors, projectPath);
+  if (errors.length === 0) {
+    console.log('No TypeScript errors found in the provided output.');
     return;
   }
   
-  // ログファイルが指定されていない場合はtscを実行
-  const tscOutput = await runTypeScriptChecker(projectPath, checker);
-  if (!tscOutput) return; // エラーがない場合は終了
-  
-  // エラー出力をパース
-  const errors = parseTscOutput(tscOutput);
-  await processErrors(errors, projectPath);
+  await processErrors(errors, targetPath);
 }

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -1,31 +1,81 @@
 import { define } from "gunshi";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { processTypeScriptErrors } from "./core";
+
+// 標準入力からデータを読み込む関数
+async function readFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+
+  // stdinがTTYの場合（パイプされていない場合）
+  if (process.stdin.isTTY) {
+    return "";
+  }
+
+  return new Promise((resolve, reject) => {
+    process.stdin.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on("end", () => {
+      const input = Buffer.concat(chunks).toString("utf-8");
+      resolve(input);
+    });
+
+    process.stdin.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+// ログファイルまたは標準入力から読み込む関数
+async function readTscOutput(logFile: string | undefined): Promise<string> {
+  // ログファイルが指定されている場合
+  if (logFile) {
+    const logFilePath = resolve(logFile);
+    console.log(`Reading log file: ${logFilePath}...`);
+    return await readFile(logFilePath, "utf-8");
+  }
+
+  // 標準入力から読み込み
+  console.log("Reading from stdin...");
+  return await readFromStdin();
+}
 
 export const addCommand = define({
   name: "add",
   args: {
-    // プロジェクトディレクトリオプション
-    project: {
+    // 処理の基準パスオプション
+    target: {
       type: "string",
-      short: "p",
-      description: "Project directory path",
+      short: "t",
+      description: "Target path for resolving file paths",
       default: ".",
     },
-    // タイプチェッカー選択オプション
-    checker: {
-      type: "string",
-      short: "c",
-      description: "TypeScript checker to use (tsc or vue-tsc)",
-      default: "tsc",
-    },
     // tscログファイルオプション
-    "log-file": {
+    logFile: {
       type: "string",
+      toKebab: true,
       short: "l",
-      description: "Path to existing tsc/vue-tsc log file to process instead of running checker",
+      description:
+        "Path to tsc/vue-tsc log file (reads from stdin if not specified)",
     },
   },
   run: async (ctx) => {
-    await processTypeScriptErrors(ctx.values);
+    const targetPath = resolve(ctx.values.target);
+    const tscOutput = await readTscOutput(ctx.values.logFile);
+
+    // 入力が空の場合
+    if (!tscOutput.trim()) {
+      console.error(
+        "Error: No input provided. Please provide a log file or pipe tsc/vue-tsc output."
+      );
+      console.error("Usage:");
+      console.error("  tsc --noEmit | bun run src/index.ts");
+      console.error("  bun run src/index.ts --log-file tsc-output.txt");
+      process.exit(1);
+    }
+
+    await processTypeScriptErrors(tscOutput, targetPath);
   },
 });

--- a/test/fixtures/react-project/package.json
+++ b/test/fixtures/react-project/package.json
@@ -10,5 +10,8 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }

--- a/test/fixtures/ts-only/package.json
+++ b/test/fixtures/ts-only/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "devDependencies": {
     "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
   }
 }


### PR DESCRIPTION
## 概要

- checkerオプションでtsc/vue-tscのコマンドを受け取って型チェック実行していたが、それは本cliの責務ではないためパイプや標準入力で受け取るようにする

## 変更

### cliオプション
- checker→廃止：外部で実行
- project→target：tscのオプションに合わせていたが、単に対象パスとなったのでremoveコマンドと同様にtargetにする
- log-file：既存オプション。ファイル経由ではない場合はパイプや標準入力でもログ内容を受け付けるように追加

### test
- 各fixtureのscriptにtypecheckオプションを追加してtscログ生成してcliに渡すように修正