### PR TITLE
add minimumReleaseAge setting for security

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,6 @@
+[install]
+minimumReleaseAge = 259200 # 3 days in seconds
+
 [test]
 # src2フォルダをテスト対象から除外
 # testフォルダ内のテストファイルのみを対象とする


### PR DESCRIPTION
## Summary

- bunfig.toml に `minimumReleaseAge` 設定を追加
- 公開から3日以上経過したパッケージのみインストール可能にすることでサプライチェーン攻撃を軽減

## Test plan

- `bun install` が正常に動作することを確認