### PR TITLE
fix: update Command type for gunshi 0.27.0

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,12 +1,12 @@
 import { cli } from "gunshi";
-import type { Args, Command } from "gunshi";
+import type { Command } from "gunshi";
 import { addCommand } from "./add";
 import { removeCommand } from "./remove";
 import { name, version } from "../../package.json";
 
 export async function run(): Promise<void> {
   // サブコマンドMapを作成
-  const subCommands = new Map<string, Command<Args>>();
+  const subCommands = new Map<string, Command>();
   subCommands.set("remove", removeCommand);
   subCommands.set("add", addCommand);
 


### PR DESCRIPTION
## Summary

- gunshi 0.27.0 で `GunshiParamsConstraint` の型定義が変更され、`Command<Args>` が型エラーになる問題を修正
- `Command<Args>` を `Command` に変更（デフォルトパラメータを使用）

## Test plan

- [ ] `bun run typecheck` が通ることを確認